### PR TITLE
Added Matches method (take 2)

### DIFF
--- a/src/RegexProvider/RegexProvider.fs
+++ b/src/RegexProvider/RegexProvider.fs
@@ -50,10 +50,20 @@ let internal typedRegex() =
                         parameters = [ProvidedParameter("input", typeof<string>)],
                         returnType = matchType,
                         InvokeCode = (fun args -> <@@ (%%args.[0]:Regex).Match(%%args.[1]) @@>))
-                matchMethod.AddXmlDoc "Searches the specified input string for the first occurence of this regular expression"
+                matchMethod.AddXmlDoc "Searches the specified input string for the first occurrence of this regular expression"
 
                 regexType.AddMember matchMethod
-                
+
+                let matchesMethod =
+                    ProvidedMethod(
+                        methodName = "Matches",
+                        parameters = [ProvidedParameter("input", typeof<string>)],
+                        returnType = seqType matchType,
+                        InvokeCode = (fun args -> <@@ (%%args.[0]:Regex).Matches(%%args.[1]) |> Seq.cast<Match> @@>))
+                matchesMethod.AddXmlDoc "Searches the specified input string for all occurrences of this regular expression"
+
+                regexType.AddMember matchesMethod
+
                 let ctor = 
                     ProvidedConstructor(
                         parameters = [], 

--- a/tests/RegexProvider.Tests/RegexProvider.Tests.fs
+++ b/tests/RegexProvider.Tests/RegexProvider.Tests.fs
@@ -25,3 +25,11 @@ let ``Can return AreaCode in simple phone number``() =
 let ``Can return PhoneNumber property in simple phone number``() =
     PhoneRegex().Match("425-123-2345").PhoneNumber.Value
     |> should equal "123-2345"
+
+type MultiplePhoneRegex = Regex< @"\b(?<AreaCode>\d{3})-(?<PhoneNumber>\d{3}-\d{4})\b" >
+[<Test>]
+let ``Can return multiple matches``() =
+    MultiplePhoneRegex().Matches("425-123-2345, 426-123-2346, 427-123-2347")
+    |> Seq.map (fun x -> x.AreaCode.Value)
+    |> List.ofSeq
+    |> should equal ["425"; "426"; "427"]


### PR DESCRIPTION
Trying again after my terrible first attempt at this patch...

The idea is to expose the [Regex.Matches](http://msdn.microsoft.com/en-us/library/e7sf90t3%28v=vs.110%29.aspx) method in a way that gives access to captured groups for each match so we can map, filter etc with strongly-typed property accessors (like we do for a single match using the existing type provider `Match` method).

The added test in this commit shows a regex that will match a phone number anywhere in a string. It gets all the `Matches` then picks out the area code of each.

The problem with my first attempt at this was I forgot `MatchCollection` doesn't implement `IEnumerable<Match>`, so property accessors tried to get `Groups` from `Object` instead of `Match` (oops). I've fixed it this time using `Seq.cast<Match>`.

I've been able to build on Windows/MS CLR (using `build.cmd`) and pass all the tests (Works On My Machine™), but I'm having trouble getting the build working on Mac/Mono so I haven't been able to test it there.

Please have a look and check it makes sense (I've only just started looking at type providers so not sure if I'm doing it wrong). If you're happy to merge it in then I'll push up a new nuget package.
