### PR TITLE
Added static Lift() method

### DIFF
--- a/src/RegexProvider/RegexProvider.fs
+++ b/src/RegexProvider/RegexProvider.fs
@@ -36,12 +36,22 @@ let internal typedRegex() =
 
                 matchType.AddMember matchMethod
                 
-
                 let regexType = erasedType<Regex> thisAssembly rootNamespace typeName
                 regexType.HideObjectMethods <- true
                 regexType.AddXmlDoc "A strongly typed interface to the regular expression '%s'"
 
                 regexType.AddMember matchType
+
+                let liftMethod =
+                    ProvidedMethod(
+                        methodName = "Lift",
+                        parameters = [ProvidedParameter("match", typeof<Match>)],
+                        returnType = matchType,
+                        InvokeCode = (fun args -> <@@ (%%args.[0]:Match) @@>),
+                        IsStaticMethod = true)
+                liftMethod.AddXmlDoc "Lifts a match to the provided match type"
+
+                regexType.AddMember liftMethod
 
                 let isMatchMethod =
                     ProvidedMethod(

--- a/tests/RegexProvider.Tests/RegexProvider.Tests.fs
+++ b/tests/RegexProvider.Tests/RegexProvider.Tests.fs
@@ -26,6 +26,20 @@ let ``Can return PhoneNumber property in simple phone number``() =
     PhoneRegex().Match("425-123-2345").PhoneNumber.Value
     |> should equal "123-2345"
 
+[<Test>]
+let ``Can lift a match to the provided match type``() =
+    let evaluator (m : System.Text.RegularExpressions.Match) = 
+        let m' = PhoneRegex.Lift m
+        
+        let areaCode = if m'.AreaCode.Value = "425" then "111" else m'.AreaCode.Value
+        sprintf "%s-%s" areaCode m'.PhoneNumber.Value
+
+    PhoneRegex().Replace("425-123-2345", evaluator)
+    |> should equal "111-123-2345"
+
+    PhoneRegex().Replace("426-123-2345", evaluator)
+    |> should equal "426-123-2345"
+
 type MultiplePhoneRegex = Regex< @"\b(?<AreaCode>\d{3})-(?<PhoneNumber>\d{3}-\d{4})\b" >
 [<Test>]
 let ``Can return multiple matches``() =


### PR DESCRIPTION
Added a static method to "lift" a `System.Text.RegularExpressions.Match` instance passed into the `MatchEvaluator` delegate function by one of the `Regex.Replace()` methods to the provided match type to take advantage of the type provider functionality inside the delegate.
