### PR TITLE
Added static Lift() method

### DIFF
--- a/src/RegexProvider/RegexProvider.fs
+++ b/src/RegexProvider/RegexProvider.fs
@@ -43,6 +43,17 @@ let internal typedRegex() =
 
                 regexType.AddMember matchType
 
+                let liftMethod =
+                    ProvidedMethod(
+                        methodName = "Lift",
+                        parameters = [ProvidedParameter("match", typeof<Match>)],
+                        returnType = matchType,
+                        InvokeCode = (fun args -> <@@ (%%args.[0]:Match) @@>),
+                        IsStaticMethod = true)
+                liftMethod.AddXmlDoc "Lifts a match to the provided match type"
+
+                regexType.AddMember liftMethod
+
                 let isMatchMethod =
                     ProvidedMethod(
                         methodName = "IsMatch",

--- a/tests/RegexProvider.Tests/RegexProvider.Tests.fs
+++ b/tests/RegexProvider.Tests/RegexProvider.Tests.fs
@@ -26,6 +26,20 @@ let ``Can return PhoneNumber property in simple phone number``() =
     PhoneRegex().Match("425-123-2345").PhoneNumber.Value
     |> should equal "123-2345"
 
+[<Test>]
+let ``Can lift a match to the provided match type``() =
+    let evaluator (m : System.Text.RegularExpressions.Match) = 
+        let m' = PhoneRegex.Lift m
+        
+        let areaCode = if m'.AreaCode.Value = "425" then "111" else m'.AreaCode.Value
+        sprintf "%s-%s" areaCode m'.PhoneNumber.Value
+
+    PhoneRegex().Replace("425-123-2345", evaluator)
+    |> should equal "111-123-2345"
+
+    PhoneRegex().Replace("426-123-2345", evaluator)
+    |> should equal "426-123-2345"
+
 type MultiplePhoneRegex = Regex< @"\b(?<AreaCode>\d{3})-(?<PhoneNumber>\d{3}-\d{4})\b" >
 [<Test>]
 let ``Can return multiple matches``() =


### PR DESCRIPTION
Added a static `Lift()` method to 'cast' match objects of type `System.Text.RegularExpressions.Match` to the provided match type to allow using the type provider IntelliSense in `MatchEvaluator` functions.

This is mainly for discussion of the concept to help find a real solution.
