### PR TITLE
Fix FSharp.Core dependency version in nuget

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ nuget Microsoft.NET.Test.Sdk
 nuget FsUnit
 nuget NUnit
 nuget NUnit.Runners
-nuget FSharp.Core
+nuget FSharp.Core >= 4.3.4
 nuget NUnit3TestAdapter
 nuget NETStandard.Library.NETFramework
 


### PR DESCRIPTION
As noticed by @sergey-tihon FSharp.Core was >= 0.0.0.0 in the nuget dependencies.
It is now >= 4.3.4