### PR TITLE
Replace with Type match evaluator, overloads and type name fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 #### 2.1.0
 * Add TryTypedMatch that returns an option - https://github.com/fsprojects/FSharp.Text.RegexProvider/issues/20
 * Add extension methods on Group to easily and safely convert to primitive types
+* Add TypedReplace with typed evaluator
+* Make type set local to provider instance to have consitent type names over rebuilds
+* Add overload for Match and Matches that takes starting position and number of occurence
+* Add ctor overload that takes a timeout
 
 #### 2.0.2 - 17.06.2019
 * Fix Nuget page is missing metadata - https://github.com/fsprojects/FSharp.Text.RegexProvider/issues/26

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -99,6 +99,33 @@ DateRegex().Match("Date: 2019-06-18").Date.AsDateTime(DateTimeStyles.AssumeUnive
 // [fsi:val it : System.DateTime = 18/06/2019 00:00:00]
 
 (**
+`TypedReplace` can be used with a match evaluator that takes a MatchType as an input.
+Here, the type of m is `NumberRegex.MatchType`, and has a Number property infered from the regular expression :
+*)
+
+type NumberRegex = Regex< @"(?<Number>\d+)" >
+
+let song = "
+    1, 2 buckle my shoe
+    3, 4 knock on the door
+    5, 6 pick up sticks
+    9, 10 a big fat hen."
+
+let numbers = 
+    Map.ofList
+        [ 1, "one"; 2, "two"; 3, "three"; 4, "four"; 5, "five"
+          6, "six"; 7, "seven"; 8, "eight"; 9, "nine"; 10, "ten"]
+
+// using typed replace, you can use typed match in the provided function
+NumberRegex().TypedReplace(song, fun m -> numbers.[m.Number.AsInt] )
+// [fsi:val it : string = ]
+// [fsi:"]
+// [fsi:    one, two buckle my shoe]
+// [fsi:    three, four knock on the door]
+// [fsi:    five, six pick up sticks]
+// [fsi:    nine, ten a big fat hen."]
+
+(**
 
 Contributing and copyright
 --------------------------

--- a/src/RegexProvider/TypeProviders.Helper.fs
+++ b/src/RegexProvider/TypeProviders.Helper.fs
@@ -101,13 +101,14 @@ module internal Helper =
     let erasedType<'T> assemblyName rootNamespace typeName hideObjectMethods = 
         ProvidedTypeDefinition(assemblyName, rootNamespace, typeName, Some(typeof<'T>), hideObjectMethods = hideObjectMethods)
 
-    let generalTypeSet = System.Collections.Concurrent.ConcurrentDictionary()
+    let createTypeSet() = System.Collections.Concurrent.ConcurrentDictionary<_, unit>()
 
-    let runtimeType<'T> typeName hideObjectMethods = ProvidedTypeDefinition(niceName generalTypeSet typeName, Some typeof<'T>, hideObjectMethods=hideObjectMethods)
+    let runtimeType<'T> typeName hideObjectMethods typeSet = ProvidedTypeDefinition(niceName typeSet typeName, Some typeof<'T>, hideObjectMethods=hideObjectMethods)
 
     let seqType ty = typedefof<seq<_>>.MakeGenericType[| ty |]
     let listType ty = typedefof<list<_>>.MakeGenericType[| ty |]
     let optionType ty = typedefof<option<_>>.MakeGenericType[| ty |]
+    let funType ty tr = typedefof<_ -> _>.MakeGenericType[| ty; tr |]
 
     // Get the assembly and namespace used to house the provided types
     let thisAssembly = System.Reflection.Assembly.GetExecutingAssembly()


### PR DESCRIPTION
This is a fix for #19 and #5 
Overloads have been added to all provided methods.

It also add a ctor with a matchTimeout parameter

It make the typeset local to each RegexProvider instance so that MatchType doesn't have a number suffix depending on the number of usages !!
